### PR TITLE
fixes

### DIFF
--- a/lib/cream/configure/rails.rb
+++ b/lib/cream/configure/rails.rb
@@ -8,14 +8,14 @@ Rails3::Plugin::Extender.new do
 
   extend_rails :controller do
     extend_from_module Cream, :role
-    extend_from_module Cream::Helper, :role_ext, :host_ext, :action_ext
+    extend_from_module Cream::Helper, :role_ext, :host_ext #, :action_ext
     extend_from_module Cream::Helper, :ability_ext, :permit_ext, :session_ext, :user_ext
   end  
 
   # extend action_view with methods from some modules
   extend_rails :view do
     extend_from_module Cream::View, :role, :host, :user_action_menu
-    extend_from_module Cream::Helper, :role_ext, :action_ext, :ability_ext, 
+    extend_from_module Cream::Helper, :role_ext, :ability_ext#, :action_ext
     extend_from_module Cream::Helper, :permit_ext, :session_ext, :user_ext
   end  
   

--- a/lib/cream/helper/host_ext.rb
+++ b/lib/cream/helper/host_ext.rb
@@ -1,5 +1,5 @@
 module Cream::Helper
-  module Host
+  module HostExt
     def localhost?
        ['localhost', '127.0.0.1'].include?(request.host)
     end           

--- a/lib/cream/helper/permit_ext.rb
+++ b/lib/cream/helper/permit_ext.rb
@@ -3,7 +3,7 @@
 # #current_ability is available to make cancan tests like user_can? and user_cannot?
 
 module Cream::Helper
-  module Action
+  module PermitExt
     def user_can? action, obj, &block
       (block ? yield : true) if current_ability.can? action, obj
     end

--- a/lib/cream/helper/user_ext.rb
+++ b/lib/cream/helper/user_ext.rb
@@ -35,7 +35,7 @@ module Cream::Helper
     end
 
     def set_language language_code
-     current_user.language_code = language_code if the_current_user && the_current_user.respond_to? :language_code # for non-guest user
+     current_user.language_code = language_code if the_current_user && the_current_user.respond_to? # :language_code # for non-guest user
      guest_options[:language_code] = language_code # for guest user
     end
   end


### PR DESCRIPTION
cream/lib/cream/helper/user_ext.rb:38: syntax error, unexpected tSYMBEG, expecting kEND (SyntaxError)
uninitialized constant Cream::Helper::HostExt (NameError)
uninitialized constant Cream::Helper::PermitExt (NameError)
cream/lib/cream/configure/rails.rb:19: syntax error, unexpected ',', expecting tCOLON2 or '[' or '.'
uninitialized constant Cream::Helper::ActionExt (NameError)
